### PR TITLE
Fixed the reference to deeplizard's YouTube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@
 				<img src = "https://img.shields.io/badge/-TensorFlow-orange">
 			</li>
 			<li>
-				<p><a href="https://www.youtube.com/user/krishnaik06">deeplizard</a></p> 
+				<p><a href="https://www.youtube.com/c/deeplizard">deeplizard</a></p> 
 				<img src = "https://img.shields.io/badge/-Machine%20Learning%20-brightgreen">
 				<img src = "https://img.shields.io/badge/-Deep%20Learning%20-green">
 				<img src = "https://img.shields.io/badge/-Deployment-orange">


### PR DESCRIPTION
Now the link correctly references deeplizard's channel